### PR TITLE
Fix compilation of extensions

### DIFF
--- a/cython_bug_demo/utils/cython_kernels/setup_package.py
+++ b/cython_bug_demo/utils/cython_kernels/setup_package.py
@@ -11,7 +11,7 @@ def get_extensions():
 
     names = [THIS_PKG_NAME + "." + src.replace(".pyx", "") for src in SOURCES]
     sources = [os.path.join(PATH_TO_PKG, srcfn) for srcfn in SOURCES]
-    include_dirs = np.get_include()
+    include_dirs = [np.get_include()]
     libraries = []
     language = "c++"
     extra_compile_args = ["-Ofast"]


### PR DESCRIPTION
``include_dirs`` was missing a list around it, so it was expanding each character of the numpy include path, e.g.:

```
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch arm64 -arch x86_64 -g -I/ -Ip -Ir -Ii -Iv -Ia -It -Ie -I/ -Iv -Ia -Ir -I/ -If -Io -Il -Id -Ie -Ir -Is -I/ -Iz -Iy -I/ -It -I1 -Il -I3 -Is -Ix -I3 -I1 -I0 -Id -I3 -Id -I6 -Ip -I0 -Ik -Iy -Ix -Iq -Iz -Il -Ir -In -Ir -I0 -I0 -I0 -I0 -Ig -Ir -I/ -IT -I/ -Ip -Ii -Ip -I- -Ib -Iu -Ii -Il -Id -I- -Ie -In -Iv -I- -Ia -If -Iv -Ih -If -Iv -Ir -Id -I/ -Io -Iv -Ie -Ir -Il -Ia -Iy -I/ -Il -Ii -Ib -I/ -Ip -Iy -It -Ih -Io -In -I3 -I. -I1 -I0 -I/ -Is -Ii -It -Ie -I- -Ip -Ia -Ic -Ik -Ia -Ig -Ie -Is -I/ -In -Iu -Im -Ip -Iy -I/ -Ic -Io -Ir -Ie -I/ -Ii -In -Ic -Il -Iu -Id -Ie -I/Users/tom/python/dev/include -I/Library/Frameworks/Python.framework/Versions/3.10/include/python3.10 -c cython_bug_demo/utils/cython_kernels/elementwise_add_cython.cpp -o build/temp.macosx-10.9-universal2-cpython-310/cython_bug_demo/utils/cython_kernels/elementwise_add_cython.o -Ofast
```